### PR TITLE
ci: add helm-docs and release actions

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,10 +1,14 @@
-name: Test Charts
+name: Lint and Test Charts
 
 on:
   pull_request:
+    branches:
+      - main
+    paths:
+      - "charts/**"
 
 jobs:
-  test:
+  lint-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -17,9 +21,15 @@ jobs:
         with:
           version: "3.14.0"
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.x"
+
+      - name: Run helm-docs
+        uses: losisin/helm-docs-github-action@8dc2304e986afbbb0b7db0a9980b6bf68c1307cf # v1.5.2
+        with:
+          fail-on-diff: true
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
@@ -44,4 +54,3 @@ jobs:
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
         run: ct install --exclude-deprecated --config ct.yaml
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "charts/**"
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@a0d2dc62c5e491af8ef6ba64a2e02bcf3fb33aa1 # v1.7.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,8 +1,6 @@
 remote: origin
 validate-maintainers: false
 target-branch: main
-chart-repos:
-  - corazawaf=https://corazawaf.github.io/charts
 helm-extra-args: --timeout 800s
 chart-dirs:
   - charts


### PR DESCRIPTION
* add helm docs step to test workflow to ensure pull requests authors have updated chart docs 
* add chart release workflow
* tweaks for test workflow
  * rename it to lint-test to better reflect its nature
  * narrow down scope to pull requests to main that changed charts themselves
  * cosmetic changes
* remove chart-repos from ct.yaml since it is intended for third-party private dependency repos, and we don't need such, and we self-reference our own repo which does not yet exist, and it triggers action failure (https://github.com/corazawaf/charts/actions/runs/15993098563/job/45124922705?pr=2)

---

After merging, please also do the following to facilitate the upcoming releases:

1) Per https://github.com/helm/chart-releaser-action#pre-requisites create an empty branch named `gh-pages` 

```
git checkout --orphan gh-pages
git rm -rf .
git commit --allow-empty -m "init gh-pages"
git push origin gh-pages
```

2) Then go to repo Settings -> Pages. Change the Source Branch to gh-pages.