### PR TITLE
fix: code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -7,6 +7,9 @@ on:
     paths:
       - "charts/**"
 
+permissions:
+  contents: read
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/corazawaf/charts/security/code-scanning/8](https://github.com/corazawaf/charts/security/code-scanning/8)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here is to set it at the workflow root (applies to all jobs), with:

- `contents: read`

This is the minimal recommended baseline and should not change existing behavior for this lint/test workflow.

Edit `.github/workflows/lint-test.yaml` near the top-level keys, inserting `permissions` between `on:` and `jobs:` (or any top-level location), without modifying job steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to enforce stricter access controls for enhanced repository security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->